### PR TITLE
Use InvariantCulture when formatting pane style CSS

### DIFF
--- a/SplitContainer.Test/V2/SplitContainerTest.cs
+++ b/SplitContainer.Test/V2/SplitContainerTest.cs
@@ -1,4 +1,5 @@
-﻿using Toolbelt.Blazor.Splitter.V2;
+﻿using System.Globalization;
+using Toolbelt.Blazor.Splitter.V2;
 
 namespace SplitContainer.Test.V2;
 
@@ -70,5 +71,89 @@ public class SplitContainerTest
 
         // Then
         styleText.Is("min-width:calc(8.5% - calc(var(--splitter-bar-size) / 2));flex:1;");
+    }
+}
+
+public class SplitContainerCultureTest
+{
+    private CultureInfo _OriginalCulture = null!;
+    private CultureInfo _OriginalUICulture = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        this._OriginalCulture = CultureInfo.CurrentCulture;
+        this._OriginalUICulture = CultureInfo.CurrentUICulture;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        CultureInfo.CurrentCulture = this._OriginalCulture;
+        CultureInfo.CurrentUICulture = this._OriginalUICulture;
+    }
+
+    // The browser's CSS calc() only accepts '.' as the decimal separator,
+    // so the style must never contain ',' regardless of the OS / app culture.
+    [TestCase("pl-PL")]
+    [TestCase("de-DE")]
+    [TestCase("fr-FR")]
+    [TestCase("ru-RU")]
+    [TestCase("nl-NL")]
+    public void GetPaneStyle_PercentSize_UsesInvariantDecimalSeparator(string cultureName)
+    {
+        CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+        CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture;
+
+        var splitContainer = new SplitContainer<double>
+        {
+            Orientation = SplitterOrientation.Horizontal,
+            UnitOfPaneSize = UnitOfPaneSize.Percent,
+        };
+
+        var styleText = splitContainer.GetPaneStyle(47.059, null);
+
+        styleText.Is("height:calc(47.059% - calc(var(--splitter-bar-size) / 2));");
+        styleText.Contains(",").IsFalse();
+    }
+
+    [TestCase("pl-PL")]
+    [TestCase("de-DE")]
+    public void GetPaneStyle_PercentMinSize_UsesInvariantDecimalSeparator(string cultureName)
+    {
+        CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+        CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture;
+
+        var splitContainer = new SplitContainer<double>
+        {
+            Orientation = SplitterOrientation.Vertical,
+            UnitOfPaneSize = UnitOfPaneSize.Percent,
+        };
+
+        var styleText = splitContainer.GetPaneStyle(null, 8.5);
+
+        styleText.Is("min-width:calc(8.5% - calc(var(--splitter-bar-size) / 2));flex:1;");
+        styleText.Contains(",").IsFalse();
+    }
+
+    // Pixel path is also culture-sensitive for fractional TSize.
+    // Latent today (most callers pass int), but the contract is "valid CSS".
+    [TestCase("pl-PL")]
+    [TestCase("de-DE")]
+    public void GetPaneStyle_PixelSize_FractionalDouble_UsesInvariantDecimalSeparator(string cultureName)
+    {
+        CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+        CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture;
+
+        var splitContainer = new SplitContainer<double>
+        {
+            Orientation = SplitterOrientation.Vertical,
+            UnitOfPaneSize = UnitOfPaneSize.Pixel,
+        };
+
+        var styleText = splitContainer.GetPaneStyle(627.5, null);
+
+        styleText.Is("width:627.5px;");
+        styleText.Contains(",").IsFalse();
     }
 }

--- a/SplitContainer/V2/SplitContainer.razor
+++ b/SplitContainer/V2/SplitContainer.razor
@@ -1,4 +1,5 @@
 @using System.Diagnostics.CodeAnalysis;
+@using System.Globalization;
 @typeparam TSize where TSize : struct
 @implements IAsyncDisposable
 @inject IJSRuntime JSRuntime
@@ -124,7 +125,7 @@
 
         static string GetSizeText(string prefix, string styleKey, string format, TSize? size, string defaultValue)
         {
-            return size.HasValue ? $"{prefix}{styleKey}:{string.Format(format, size.Value)}" : defaultValue;
+            return size.HasValue ? $"{prefix}{styleKey}:{string.Format(CultureInfo.InvariantCulture, format, size.Value)}" : defaultValue;
         }
         ;
 


### PR DESCRIPTION
## Problem

- Found it while using the package in [BlazingStory](https://github.com/jsakamoto/BlazingStory) on a Polish locale machine. localStorage stored the correct decimal; only the rendered DOM was wrong.
- `SplitContainer<TSize>.GetPaneStyle` formats the pane size into an inline `style="..."` value with `string.Format` and no
  `IFormatProvider`, so the rendered CSS uses `CurrentCulture`'s decimal separator. On comma-decimal locales (pl-PL, de-DE, fr-FR, ru-RU, nl-NL, etc.), `calc(47,059% - …)` is invalid CSS, browsers drop the `width`/`height`, and the pane snaps back to content height after every drag.

## Problem

```html
<!-- pl-PL machine, fractional pane size 47.059 -->
<div class="pane-of-split-container"
     style="height:calc(47,059% - calc(var(--splitter-bar-size) / 2));">
```

## Fix

- Pass `CultureInfo.InvariantCulture` to `string.Format`. CSS only accepts `.` as the decimal separator, so invariant is correct in every locale.
- Adds culture-parameterised tests across five comma-decimal locales, covering Percent size, Percent min-size, and the latent fractional Pixel path.